### PR TITLE
need to install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Helmi <helmi@tuxuri.com>
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
 RUN apt-get -y update
+RUN apt-get -y install ca-certificates
 RUN apt-get -y install wget
 RUN wget --quiet --no-check-certificate -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main" >> /etc/apt/sources.list


### PR DESCRIPTION
otherwise SSL doesn't work in the container and you can't successfully do `CREATE EXTENSION postgis;` after you create a db
