### PR TITLE
Add in declarations for username and password variables (docker/docker)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+USERNAME=docker
+PASS=docker
 DATADIR="/var/lib/postgresql/9.3/main"
 CONF="/etc/postgresql/9.3/main/postgresql.conf"
 POSTGRES="/usr/lib/postgresql/9.3/bin/postgres"


### PR DESCRIPTION
The script was failing to create the user properly when I was trying to mount the data directory using the volume parameter; my logs were showing this:

```
WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.

PostgreSQL stand-alone backend 9.3.5
2014-07-27 03:28:20 UTC ERROR:  syntax error at or near "WITH SUPERUSER" at character 14
2014-07-27 03:28:20 UTC STATEMENT:  CREATE USER  WITH SUPERUSER PASSWORD '';
```

I just added the variables to the start.sh script, I'm not sure if the values were supposed to be coming in externally somehow or what.
