### PR TITLE
Remove ca-certificates as this can cause child projects to error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Helmi <helmi@tuxuri.com>
 
 RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
 RUN apt-get -y update
-RUN apt-get -y install ca-certificates
 RUN apt-get -y install wget
 RUN wget --quiet --no-check-certificate -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" >> /etc/apt/sources.list


### PR DESCRIPTION
## Explanation

As noted in the comment by user [base698](https://hub.docker.com/u/base698/) on the `docker-postgis` [Docker hub comments](https://registry.hub.docker.com/u/helmi03/docker-postgis/), the inclusion of the line `RUN apt-get -y install ca-certificates` causes Dockerfiles that use `docker-postgis` as a base to fail if they try to start postgres, for example in order to create and populate a database.

Example 1 below shows what happens when a dependent project attempts to start postgres.
Example 2 shows what happens with the updated `docker-postgis` Dockerfile.
## Example 1 :x:
### Dockerfile

``` docker
FROM    helmi03/docker-postgis
RUN     service postgresql start
CMD     ["./start.sh"]
```
### Build output

```
Sending build context to Docker daemon  2.56 kB
Sending build context to Docker daemon
Step 0 : FROM    helmi03/docker-postgis
 ---> 5d1aa766f751
Step 1 : RUN     service postgresql start
 ---> Running in 8ee8f71d2429
 * Starting PostgreSQL 9.3 database server
 * The PostgreSQL server failed to start. Please check the log output:
2014-09-01 12:47:57 UTC FATAL:  could not access private key file "/etc/ssl/private/ssl-cert-snakeoil.key": Permission denied
   ...fail!
2014/09/01 13:47:58 The command [/bin/sh -c service postgresql start] returned a non-zero code: 1
```
## Example 2 :white_check_mark:
### Dockerfile

``` docker
FROM    andystanton/docker-postgis
RUN     service postgresql start
CMD     ["./start.sh"]
```
### Build output

```
Sending build context to Docker daemon  2.56 kB
Sending build context to Docker daemon
Step 0 : FROM    andystanton/docker-postgis
 ---> 12a87baeabdc
Step 1 : RUN     service postgresql start
 ---> Running in 12d7533c2c71
 * Starting PostgreSQL 9.3 database server
   ...done.
 ---> 7056a58643b9
Removing intermediate container 12d7533c2c71
Step 2 : CMD     ["./start.sh"]
 ---> Running in 3918e2239a73
 ---> c4a1681a4aa2
Removing intermediate container 3918e2239a73
Successfully built c4a1681a4aa2
```
